### PR TITLE
feat: add compact mode

### DIFF
--- a/packages/prettier-plugin-vertical-align/src/compact.ts
+++ b/packages/prettier-plugin-vertical-align/src/compact.ts
@@ -1,0 +1,288 @@
+import type { AstPath, Doc } from "prettier";
+import prettier from "prettier";
+
+const { doc } = prettier;
+const { hardline, indent } = doc.builders;
+
+type Node = AstPath["node"];
+
+export const compactAlignSymbol = Symbol("compactAlign");
+
+let compactDepth = 0;
+
+export function enterCompactDepth(): void {
+	compactDepth++;
+}
+
+export function exitCompactDepth(): void {
+	compactDepth--;
+}
+
+export function isInsideCompact(): boolean {
+	return compactDepth > 0;
+}
+
+// --- Compact align config ---
+
+let cachedPatterns: { input: string[]; regexps: RegExp[] } | null = null;
+
+function parseCompactPatterns(patterns: string[]): RegExp[] {
+	if (!patterns || patterns.length === 0) return [];
+	if (cachedPatterns && cachedPatterns.input === patterns) return cachedPatterns.regexps;
+	const regexps = patterns.filter(Boolean).map((p) => new RegExp(p));
+	cachedPatterns = { input: patterns, regexps };
+	return regexps;
+}
+
+let cachedLineOffsets: { text: string; offsets: number[] } | null = null;
+
+function getLineOffsets(text: string): number[] {
+	if (cachedLineOffsets && cachedLineOffsets.text === text) return cachedLineOffsets.offsets;
+	const offsets = [0];
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === "\n") offsets.push(i + 1);
+	}
+	cachedLineOffsets = { text, offsets };
+	return offsets;
+}
+
+function getNodeSourcePrefix(node: Node, originalText: string, lineOffsets: number[], maxLen: number): string {
+	if (!node.loc) return "";
+	const charOffset = lineOffsets[node.loc.start.line - 1] + node.loc.start.column;
+	return originalText.slice(charOffset, charOffset + maxLen);
+}
+
+export function matchesCompactPattern(node: Node, options: any): boolean {
+	const patterns = parseCompactPatterns(options.compactFunctionCallPatterns);
+	if (patterns.length === 0) return false;
+	if (!node.loc) return false;
+	const lineOffsets = getLineOffsets(options.originalText);
+	const maxLen = Math.max(...patterns.map((r) => r.source.length)) + 20;
+	const prefix = getNodeSourcePrefix(node, options.originalText, lineOffsets, maxLen);
+	return patterns.some((r) => r.test(prefix));
+}
+
+// --- Doc flattening ---
+
+export function flattenDoc(d: Doc): Doc {
+	if (typeof d === "string") return d;
+	if (Array.isArray(d)) return d.map(flattenDoc);
+	if (!d || typeof d !== "object") return d;
+
+	switch ((d as any).type) {
+		case "line":
+			return (d as any).soft ? "" : " ";
+		case "break-parent":
+			return "";
+		case "group":
+			return flattenDoc((d as any).contents);
+		case "indent":
+			return flattenDoc((d as any).contents);
+		case "align":
+			return flattenDoc((d as any).contents);
+		case "if-break":
+			return flattenDoc((d as any).flatContents ?? "");
+		case "fill":
+			return (d as any).parts.map(flattenDoc);
+		case "concat":
+			return (d as any).parts.map(flattenDoc);
+		case "indent-if-break":
+			return flattenDoc((d as any).contents);
+		case "line-suffix":
+			return flattenDoc((d as any).contents);
+		case "line-suffix-boundary":
+			return "";
+		case "label":
+			return flattenDoc((d as any).contents);
+		default:
+			return d;
+	}
+}
+
+// --- AST helpers ---
+
+function nodeHasComments(node: Node): boolean {
+	if (!node || typeof node !== "object") return false;
+	if (Array.isArray(node.comments) && node.comments.length > 0) return true;
+	for (const key of Object.keys(node)) {
+		if (key === "loc" || key === "type" || key === "start" || key === "end" || key === "range" || key === "comments")
+			continue;
+		const val = node[key];
+		if (Array.isArray(val)) {
+			for (const item of val) {
+				if (item && typeof item === "object" && item.type && nodeHasComments(item)) return true;
+			}
+		} else if (val && typeof val === "object" && val.type && nodeHasComments(val)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function callHasBlockFunctionArg(node: Node): boolean {
+	return node.arguments?.some(
+		(arg: Node) =>
+			arg.type === "FunctionExpression" ||
+			(arg.type === "ArrowFunctionExpression" && arg.body?.type === "BlockStatement"),
+	);
+}
+
+export function shouldSkipCompact(node: Node): boolean {
+	return nodeHasComments(node) || callHasBlockFunctionArg(node);
+}
+
+// --- Compact call alignment ---
+
+function isStatementContainer(node: Node): boolean {
+	return node.type === "Program" || node.type === "BlockStatement";
+}
+
+export function isCompactStatementContainer(node: Node): boolean {
+	return isStatementContainer(node);
+}
+
+function getCallFromStatement(child: Node): Node | null {
+	if (child.type === "ExpressionStatement" && child.expression?.type === "CallExpression") {
+		return child.expression;
+	}
+	return null;
+}
+
+export function scanCompactCallGroups(node: Node, options: any): void {
+	const patterns = parseCompactPatterns(options.compactFunctionCallPatterns);
+	if (patterns.length === 0) return;
+	const maxArgs: number = options.compactFunctionCallMaxArgs || Infinity;
+
+	const children: Node[] = node.body;
+	if (!children || !Array.isArray(children)) return;
+
+	const lineOffsets = getLineOffsets(options.originalText);
+	const maxLen = Math.max(...patterns.map((r) => r.source.length)) + 20;
+
+	let groups: Node[][] = [];
+	let prevLine = -Infinity;
+
+	for (const child of children) {
+		const call = getCallFromStatement(child);
+		if (!call || !call.arguments || call.arguments.length === 0) {
+			prevLine = -Infinity;
+			continue;
+		}
+
+		const prefix = getNodeSourcePrefix(call, options.originalText, lineOffsets, maxLen);
+		if (!patterns.some((r) => r.test(prefix)) || shouldSkipCompact(call)) {
+			prevLine = -Infinity;
+			continue;
+		}
+
+		const childStart = child.loc.start.line;
+		if (prevLine === -Infinity || (options.alignInGroups === "always" && prevLine !== childStart - 1)) {
+			groups.push([]);
+		}
+
+		groups.at(-1)!.push(call);
+		prevLine = child.loc.end.line;
+	}
+
+	for (const grp of groups.filter((g) => g.length > 1)) {
+		const maxArgCount = Math.max(...grp.map((c) => c.arguments.length));
+		const argWidths: number[] = [];
+
+		let maxCalleeWidth = 0;
+		for (const call of grp) {
+			const calleeWidth = call.callee.loc.end.column - call.callee.loc.start.column;
+			maxCalleeWidth = Math.max(maxCalleeWidth, calleeWidth);
+		}
+
+		const alignedArgCount = Math.min(maxArgCount, maxArgs - 1);
+		for (let i = 0; i < alignedArgCount; i++) {
+			let maxWidth = 0;
+			for (const call of grp) {
+				if (i < call.arguments.length) {
+					const arg = call.arguments[i];
+					if (i === 0 && arg.type === "ArrayExpression") continue;
+					const width = arg.loc.end.column - arg.loc.start.column;
+					maxWidth = Math.max(maxWidth, width);
+				}
+			}
+			argWidths.push(maxWidth);
+		}
+
+		for (const call of grp) {
+			call[compactAlignSymbol] = { argWidths, maxCalleeWidth };
+		}
+	}
+}
+
+export function printAlignedCompactCall(
+	node: Node,
+	path: AstPath,
+	options: any,
+	_print: (path: AstPath) => Doc,
+): Doc {
+	const alignInfo = node[compactAlignSymbol] as { argWidths: number[]; maxCalleeWidth: number };
+	const callee = flattenDoc(path.call(_print, "callee"));
+	const calleeWidth = node.callee.loc.end.column - node.callee.loc.start.column;
+	const calleePadding = alignInfo.maxCalleeWidth - calleeWidth;
+
+	const firstArgIsArray = node.arguments[0]?.type === "ArrayExpression";
+
+	if (firstArgIsArray) {
+		const elements: Doc[] = [];
+		path.each((elemPath: AstPath, index: number) => {
+			if (index > 0) elements.push(",", hardline);
+			elements.push(elemPath.call(_print));
+		}, "arguments", 0, "elements");
+		const arrayDoc = ["[", indent([hardline, ...elements]), ",", hardline, "]"];
+		const remainingArgs: Doc[] = [];
+		for (let i = 1; i < node.arguments.length; i++) {
+			remainingArgs.push(flattenDoc(path.call(_print, "arguments", i)));
+		}
+
+		// After the array group breaks, "]" lands at the base indent (same as callee).
+		// We add "," then pad to reach the column where arg[1] starts in non-array calls.
+		// That column (relative to base indent) = maxCalleeWidth + 1("(") + argWidths[0] + 2(", ")
+		// After "]," we're at base indent + 2, so padding = maxCalleeWidth + argWidths[0] + 1
+		const paddingAfterArray = alignInfo.maxCalleeWidth + (alignInfo.argWidths[0] || 0) + 1;
+
+		const parts: Doc[] = [callee, " ".repeat(calleePadding) + "(", arrayDoc, ",", " ".repeat(paddingAfterArray)];
+		for (let i = 0; i < remainingArgs.length; i++) {
+			parts.push(remainingArgs[i]);
+			if (i < remainingArgs.length - 1) {
+				const argIdx = i + 1;
+				if (argIdx < alignInfo.argWidths.length) {
+					const arg = node.arguments[i + 1];
+					const argWidth = arg.loc.end.column - arg.loc.start.column;
+					const padding = Math.max(alignInfo.argWidths[argIdx] - argWidth, 0);
+					parts.push("," + " ".repeat(padding + 1));
+				} else {
+					parts.push(", ");
+				}
+			}
+		}
+		parts.push(")");
+		return parts;
+	}
+
+	const args: Doc[] = [];
+	path.each((argPath: AstPath) => {
+		args.push(flattenDoc(argPath.call(_print)));
+	}, "arguments");
+
+	const parts: Doc[] = [callee, " ".repeat(calleePadding) + "("];
+	for (let i = 0; i < args.length; i++) {
+		parts.push(args[i]);
+		if (i < args.length - 1) {
+			if (i < alignInfo.argWidths.length) {
+				const arg = node.arguments[i];
+				const argWidth = arg.loc.end.column - arg.loc.start.column;
+				const padding = Math.max(alignInfo.argWidths[i] - argWidth, 0);
+				parts.push("," + " ".repeat(padding + 1));
+			} else {
+				parts.push(", ");
+			}
+		}
+	}
+	parts.push(")");
+	return parts;
+}

--- a/packages/prettier-plugin-vertical-align/src/compact.ts
+++ b/packages/prettier-plugin-vertical-align/src/compact.ts
@@ -22,44 +22,27 @@ export function isInsideCompact(): boolean {
 	return compactDepth > 0;
 }
 
-// --- Compact align config ---
+// --- Compact pattern config ---
 
-let cachedPatterns: { input: string[]; regexps: RegExp[] } | null = null;
+let cachedConfig: { input: string[]; regexps: RegExp[]; maxLen: number } | null = null;
 
-function parseCompactPatterns(patterns: string[]): RegExp[] {
-	if (!patterns || patterns.length === 0) return [];
-	if (cachedPatterns && cachedPatterns.input === patterns) return cachedPatterns.regexps;
+function getCompactConfig(patterns: string[]): { regexps: RegExp[]; maxLen: number } {
+	if (!patterns || patterns.length === 0) return { regexps: [], maxLen: 0 };
+	if (cachedConfig && cachedConfig.input === patterns) return cachedConfig;
 	const regexps = patterns.filter(Boolean).map((p) => new RegExp(p));
-	cachedPatterns = { input: patterns, regexps };
-	return regexps;
-}
-
-let cachedLineOffsets: { text: string; offsets: number[] } | null = null;
-
-function getLineOffsets(text: string): number[] {
-	if (cachedLineOffsets && cachedLineOffsets.text === text) return cachedLineOffsets.offsets;
-	const offsets = [0];
-	for (let i = 0; i < text.length; i++) {
-		if (text[i] === "\n") offsets.push(i + 1);
-	}
-	cachedLineOffsets = { text, offsets };
-	return offsets;
-}
-
-function getNodeSourcePrefix(node: Node, originalText: string, lineOffsets: number[], maxLen: number): string {
-	if (!node.loc) return "";
-	const charOffset = lineOffsets[node.loc.start.line - 1] + node.loc.start.column;
-	return originalText.slice(charOffset, charOffset + maxLen);
+	const maxLen = Math.max(...regexps.map((r) => r.source.length)) + 20;
+	const result = { input: patterns, regexps, maxLen };
+	cachedConfig = result;
+	return result;
 }
 
 export function matchesCompactPattern(node: Node, options: any): boolean {
-	const patterns = parseCompactPatterns(options.compactFunctionCallPatterns);
-	if (patterns.length === 0) return false;
-	if (!node.loc) return false;
-	const lineOffsets = getLineOffsets(options.originalText);
-	const maxLen = Math.max(...patterns.map((r) => r.source.length)) + 20;
-	const prefix = getNodeSourcePrefix(node, options.originalText, lineOffsets, maxLen);
-	return patterns.some((r) => r.test(prefix));
+	const { regexps, maxLen } = getCompactConfig(options.compactFunctionCallPatterns);
+	if (!regexps.length) return false;
+	const start: number | undefined = node.start ?? node.range?.[0];
+	if (start == null) return false;
+	const prefix = options.originalText.slice(start, start + maxLen);
+	return regexps.some((r) => r.test(prefix));
 }
 
 // --- Doc flattening ---
@@ -73,27 +56,20 @@ export function flattenDoc(d: Doc): Doc {
 		case "line":
 			return (d as any).soft ? "" : " ";
 		case "break-parent":
+		case "line-suffix-boundary":
 			return "";
 		case "group":
-			return flattenDoc((d as any).contents);
 		case "indent":
-			return flattenDoc((d as any).contents);
 		case "align":
+		case "indent-if-break":
+		case "line-suffix":
+		case "label":
 			return flattenDoc((d as any).contents);
 		case "if-break":
 			return flattenDoc((d as any).flatContents ?? "");
 		case "fill":
-			return (d as any).parts.map(flattenDoc);
 		case "concat":
 			return (d as any).parts.map(flattenDoc);
-		case "indent-if-break":
-			return flattenDoc((d as any).contents);
-		case "line-suffix":
-			return flattenDoc((d as any).contents);
-		case "line-suffix-boundary":
-			return "";
-		case "label":
-			return flattenDoc((d as any).contents);
 		default:
 			return d;
 	}
@@ -119,58 +95,40 @@ function nodeHasComments(node: Node): boolean {
 	return false;
 }
 
-function callHasBlockFunctionArg(node: Node): boolean {
-	return node.arguments?.some(
-		(arg: Node) =>
-			arg.type === "FunctionExpression" ||
-			(arg.type === "ArrowFunctionExpression" && arg.body?.type === "BlockStatement"),
-	);
-}
-
 export function shouldSkipCompact(node: Node): boolean {
-	return nodeHasComments(node) || callHasBlockFunctionArg(node);
+	return (
+		nodeHasComments(node) ||
+		node.arguments?.some(
+			(arg: Node) =>
+				arg.type === "FunctionExpression" ||
+				(arg.type === "ArrowFunctionExpression" && arg.body?.type === "BlockStatement"),
+		)
+	);
 }
 
 // --- Compact call alignment ---
 
-function isStatementContainer(node: Node): boolean {
-	return node.type === "Program" || node.type === "BlockStatement";
-}
-
-export function isCompactStatementContainer(node: Node): boolean {
-	return isStatementContainer(node);
-}
-
-function getCallFromStatement(child: Node): Node | null {
-	if (child.type === "ExpressionStatement" && child.expression?.type === "CallExpression") {
-		return child.expression;
-	}
-	return null;
-}
-
 export function scanCompactCallGroups(node: Node, options: any): void {
-	const patterns = parseCompactPatterns(options.compactFunctionCallPatterns);
-	if (patterns.length === 0) return;
+	if (!getCompactConfig(options.compactFunctionCallPatterns).regexps.length) return;
 	const maxArgs: number = options.compactFunctionCallMaxArgs || Infinity;
 
 	const children: Node[] = node.body;
 	if (!children || !Array.isArray(children)) return;
 
-	const lineOffsets = getLineOffsets(options.originalText);
-	const maxLen = Math.max(...patterns.map((r) => r.source.length)) + 20;
-
 	let groups: Node[][] = [];
 	let prevLine = -Infinity;
 
 	for (const child of children) {
-		const call = getCallFromStatement(child);
+		const call =
+			child.type === "ExpressionStatement" && child.expression?.type === "CallExpression"
+				? child.expression
+				: null;
 		if (!call || !call.arguments || call.arguments.length === 0) {
 			prevLine = -Infinity;
 			continue;
 		}
 
-		const prefix = getNodeSourcePrefix(call, options.originalText, lineOffsets, maxLen);
-		if (!patterns.some((r) => r.test(prefix)) || shouldSkipCompact(call)) {
+		if (!matchesCompactPattern(call, options) || shouldSkipCompact(call)) {
 			prevLine = -Infinity;
 			continue;
 		}
@@ -214,10 +172,35 @@ export function scanCompactCallGroups(node: Node, options: any): void {
 	}
 }
 
+/**
+ * Appends printed args to `parts` with column-aligned padding separators.
+ * `offset` maps printed arg index to original argument/argWidths index
+ * (0 for normal args, 1 for remaining args after an array first-arg).
+ */
+function pushPaddedArgs(
+	parts: Doc[],
+	printedArgs: Doc[],
+	nodeArgs: Node[],
+	argWidths: number[],
+	offset: number,
+): void {
+	for (let i = 0; i < printedArgs.length; i++) {
+		parts.push(printedArgs[i]);
+		if (i < printedArgs.length - 1) {
+			const ai = i + offset;
+			if (ai < argWidths.length) {
+				const argWidth = nodeArgs[ai].loc.end.column - nodeArgs[ai].loc.start.column;
+				parts.push("," + " ".repeat(Math.max(argWidths[ai] - argWidth, 0) + 1));
+			} else {
+				parts.push(", ");
+			}
+		}
+	}
+}
+
 export function printAlignedCompactCall(
 	node: Node,
 	path: AstPath,
-	options: any,
 	_print: (path: AstPath) => Doc,
 ): Doc {
 	const alignInfo = node[compactAlignSymbol] as { argWidths: number[]; maxCalleeWidth: number };
@@ -225,9 +208,7 @@ export function printAlignedCompactCall(
 	const calleeWidth = node.callee.loc.end.column - node.callee.loc.start.column;
 	const calleePadding = alignInfo.maxCalleeWidth - calleeWidth;
 
-	const firstArgIsArray = node.arguments[0]?.type === "ArrayExpression";
-
-	if (firstArgIsArray) {
+	if (node.arguments[0]?.type === "ArrayExpression") {
 		const elements: Doc[] = [];
 		path.each((elemPath: AstPath, index: number) => {
 			if (index > 0) elements.push(",", hardline);
@@ -246,20 +227,7 @@ export function printAlignedCompactCall(
 		const paddingAfterArray = alignInfo.maxCalleeWidth + (alignInfo.argWidths[0] || 0) + 1;
 
 		const parts: Doc[] = [callee, " ".repeat(calleePadding) + "(", arrayDoc, ",", " ".repeat(paddingAfterArray)];
-		for (let i = 0; i < remainingArgs.length; i++) {
-			parts.push(remainingArgs[i]);
-			if (i < remainingArgs.length - 1) {
-				const argIdx = i + 1;
-				if (argIdx < alignInfo.argWidths.length) {
-					const arg = node.arguments[i + 1];
-					const argWidth = arg.loc.end.column - arg.loc.start.column;
-					const padding = Math.max(alignInfo.argWidths[argIdx] - argWidth, 0);
-					parts.push("," + " ".repeat(padding + 1));
-				} else {
-					parts.push(", ");
-				}
-			}
-		}
+		pushPaddedArgs(parts, remainingArgs, node.arguments, alignInfo.argWidths, 1);
 		parts.push(")");
 		return parts;
 	}
@@ -270,19 +238,7 @@ export function printAlignedCompactCall(
 	}, "arguments");
 
 	const parts: Doc[] = [callee, " ".repeat(calleePadding) + "("];
-	for (let i = 0; i < args.length; i++) {
-		parts.push(args[i]);
-		if (i < args.length - 1) {
-			if (i < alignInfo.argWidths.length) {
-				const arg = node.arguments[i];
-				const argWidth = arg.loc.end.column - arg.loc.start.column;
-				const padding = Math.max(alignInfo.argWidths[i] - argWidth, 0);
-				parts.push("," + " ".repeat(padding + 1));
-			} else {
-				parts.push(", ");
-			}
-		}
-	}
+	pushPaddedArgs(parts, args, node.arguments, alignInfo.argWidths, 0);
 	parts.push(")");
 	return parts;
 }

--- a/packages/prettier-plugin-vertical-align/src/index.ts
+++ b/packages/prettier-plugin-vertical-align/src/index.ts
@@ -1,4 +1,4 @@
-import type { Parser, ParserOptions, Printer, SupportOption, SupportOptions } from "prettier";
+import type { Parser, Printer, SupportOptions } from "prettier";
 import tsParsers from "prettier/parser-typescript.js";
 import babelParsers from "prettier/parser-babel.js";
 import { printer } from "./printer.js";

--- a/packages/prettier-plugin-vertical-align/src/index.ts
+++ b/packages/prettier-plugin-vertical-align/src/index.ts
@@ -28,6 +28,21 @@ export const options: SupportOptions = {
 		],
 		description: "Whether all properties in a group should align the same, or it's on a per-group basis.",
 	},
+	compactFunctionCallPatterns: {
+		type: "string",
+		array: true,
+		category: "Global",
+		default: [{ value: [] }],
+		description:
+			"Regular expression patterns. Matching call expressions are compacted to one line with arguments vertically aligned across consecutive calls.",
+	},
+	compactFunctionCallMaxArgs: {
+		type: "int",
+		category: "Global",
+		default: 0,
+		description:
+			"Max number of arguments to align on a single line. 0 means no limit.",
+	},
 };
 // Do not export printers, as prettier does not allow composing printers.
 // Instead we wrap the original printer

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -1,8 +1,19 @@
-import type { AstPath, Printer } from "prettier";
+import type { AstPath, Doc, Printer } from "prettier";
 import prettier from "prettier";
-// import { inspect } from "node:util";
 const { doc } = prettier;
 import { getOriginalPrinter } from "./original-printer.js";
+import {
+	compactAlignSymbol,
+	enterCompactDepth,
+	exitCompactDepth,
+	flattenDoc,
+	isCompactStatementContainer,
+	isInsideCompact,
+	matchesCompactPattern,
+	printAlignedCompactCall,
+	scanCompactCallGroups,
+	shouldSkipCompact,
+} from "./compact.js";
 
 const { group, softline, line, ifBreak, indent } = doc.builders;
 
@@ -10,20 +21,8 @@ type Node = AstPath["node"];
 const keyLengthSymbol = Symbol("keyLength");
 const typeAnnotationPrefix = Symbol("typeAnnotation");
 
-function shouldMoveCompletelyToNextLine(node: Node) {
-	return node.type === "LogicalExpression";
-
-	// Alternative implementation:
-	// return node.value.type !== "ObjectExpression" &&
-	//   node.value.type !== "ArrayExpression" &&
-	//   node.value.type !== "CallExpression" &&
-	//   node.value.type !== "AwaitExpression";
-}
-
 export const printer: Printer = {
 	print(path, options, _print, ...args) {
-		// const originalPrinter = options.printer as Printer;
-
 		const node = path.node;
 
 		// See https://github.com/huggingface/prettier-plugin-vertical-align/issues/5
@@ -31,24 +30,33 @@ export const printer: Printer = {
 			return getOriginalPrinter().print(path, options, _print, ...args);
 		}
 
-		// if (node.comments) {
-		// 	console.log("!!COMMENTS");
-		// }
+		// Compact call with alignment info — always takes priority
+		if (node[compactAlignSymbol]) {
+			return printAlignedCompactCall(node, path, options, _print);
+		}
 
-		// if (node.type === "Program") {
-		//   console.log("node", inspect(node.body, { depth: 10 }));
-		// }
+		// Inside a compact expression — skip custom alignment, use original printer
+		if (isInsideCompact()) {
+			return getOriginalPrinter().print(path, options, _print, ...args);
+		}
+
+		// Compact pattern match (non-aligned): flatten to single line
+		if (node.type === "CallExpression" && matchesCompactPattern(node, options) && !shouldSkipCompact(node)) {
+			enterCompactDepth();
+			try {
+				return flattenDoc(getOriginalPrinter().print(path, options, _print, ...args));
+			} finally {
+				exitCompactDepth();
+			}
+		}
 
 		if (node[keyLengthSymbol]) {
 			const keyLength = node[keyLengthSymbol];
 			const addedLength = keyLength - (node.key.loc.end.column - node.key.loc.start.column) - modifierLength(node);
 
-			// console.log("keyLength", keyLength);
-
 			switch (node.type) {
 				case "Property":
 				case "ObjectProperty": {
-					// console.log(node.value.type);
 					return group([
 						node.computed ? "[" : "",
 						path.call(_print, "key"),
@@ -77,8 +85,6 @@ export const printer: Printer = {
 			let groups: Node[][] = [];
 			let prevLine = -Infinity;
 
-			// console.log("node", node);
-			// console.log("node", inspect(node, {depth: 10}));
 			const properties: Node[] = nodeProperties(node).filter((node: Node) =>
 				!isProperty(node) || !node[valueField(node)]?.loc
 					? node.loc.start.line === node.loc.end.line
@@ -118,9 +124,26 @@ export const printer: Printer = {
 			}
 		}
 
+		// Scan blocks for consecutive compact call expressions
+		if (isCompactStatementContainer(node)) {
+			scanCompactCallGroups(node, options);
+		}
+
 		return getOriginalPrinter().print(path, options, _print, ...args);
 	},
 };
+
+// --- Existing helpers ---
+
+function shouldMoveCompletelyToNextLine(node: Node) {
+	return node.type === "LogicalExpression";
+
+	// Alternative implementation:
+	// return node.value.type !== "ObjectExpression" &&
+	//   node.value.type !== "ArrayExpression" &&
+	//   node.value.type !== "CallExpression" &&
+	//   node.value.type !== "AwaitExpression";
+}
 
 function isPropertyContainer(node: AstPath["node"]) {
 	return (

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -6,16 +6,12 @@ import {
 	compactAlignSymbol,
 	enterCompactDepth,
 	exitCompactDepth,
-	flattenDoc,
-	isCompactStatementContainer,
 	isInsideCompact,
-	matchesCompactPattern,
 	printAlignedCompactCall,
 	scanCompactCallGroups,
-	shouldSkipCompact,
 } from "./compact.js";
 
-const { group, softline, line, ifBreak, indent } = doc.builders;
+const { group, line, ifBreak, indent } = doc.builders;
 
 type Node = AstPath["node"];
 const keyLengthSymbol = Symbol("keyLength");
@@ -32,22 +28,17 @@ export const printer: Printer = {
 
 		// Compact call with alignment info — always takes priority
 		if (node[compactAlignSymbol]) {
-			return printAlignedCompactCall(node, path, options, _print);
+			try {
+				enterCompactDepth();
+				return printAlignedCompactCall(node, path, _print);
+			} finally {
+				exitCompactDepth();
+			}
 		}
 
 		// Inside a compact expression — skip custom alignment, use original printer
 		if (isInsideCompact()) {
 			return getOriginalPrinter().print(path, options, _print, ...args);
-		}
-
-		// Compact pattern match (non-aligned): flatten to single line
-		if (node.type === "CallExpression" && matchesCompactPattern(node, options) && !shouldSkipCompact(node)) {
-			enterCompactDepth();
-			try {
-				return flattenDoc(getOriginalPrinter().print(path, options, _print, ...args));
-			} finally {
-				exitCompactDepth();
-			}
 		}
 
 		if (node[keyLengthSymbol]) {
@@ -125,7 +116,7 @@ export const printer: Printer = {
 		}
 
 		// Scan blocks for consecutive compact call expressions
-		if (isCompactStatementContainer(node)) {
+		if (node.type === "Program" || node.type === "BlockStatement") {
 			scanCompactCallGroups(node, options);
 		}
 

--- a/packages/test-compact/.prettierrc
+++ b/packages/test-compact/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"printWidth": 120,
+	"tabWidth": 2,
+	"useTabs": true,
+	"alignInGroups": "always",
+	"compactFunctionCallPatterns": ["^foo\\.", "^console\\."],
+	"compactFunctionCallMaxArgs": 0,
+	"plugins": ["@huggingface/prettier-plugin-vertical-align"]
+}

--- a/packages/test-compact/package.json
+++ b/packages/test-compact/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "test-compact",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"test": "prettier --check src",
+		"test:write": "prettier --write src"
+	},
+	"private": true,
+	"dependencies": {
+		"@huggingface/prettier-plugin-vertical-align": "workspace:*",
+		"@types/node": "^22.0.0",
+		"prettier": "^3.3.3",
+		"typescript": "^5.6.2"
+	},
+	"type": "module",
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"packageManager": "pnpm@9.11.0"
+}

--- a/packages/test-compact/src/index.ts
+++ b/packages/test-compact/src/index.ts
@@ -1,0 +1,51 @@
+declare const foo: any;
+declare const bar: any;
+declare const longBar: any;
+declare const baz: any;
+
+// Consecutive matching calls — arguments vertically aligned
+foo.method(baz,     bar);
+foo.method(longBar, bar);
+
+// Blank line separates groups (alignInGroups: "always")
+foo.mthd("short",      bar);
+foo.mthd("muchlonger", bar);
+
+// Non-matching expression — formatted normally with property alignment
+const x = {
+	a:  1,
+	bc: {
+		x: 1,
+	},
+};
+
+// Another group of aligned calls
+console.log("short",      "world", 1);
+console.log("muchlonger", "world", 2);
+console.log("x",          "world", 3);
+
+// Three-arg alignment
+foo.method("short",      baz,     bar);
+foo.method("muchlonger", longBar, bar);
+
+// Different callee widths — padding after ( aligns all arguments
+foo.mthd      ("short", baz, bar);
+foo.longMethod("short", baz, bar);
+
+// Complex args with nested object
+foo.method([
+	"superreallylong",
+	"short",
+	"x",
+],           baz.biz({ foo: [] }));
+foo.method([
+	"short",
+	"muchlonger",
+],           baz.biz({ bar }));
+
+// Array first arg — array stays multi-line, remaining args aligned
+foo.method([
+	"short",
+	"short",
+],                  bar);
+foo.method("short", bar);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,21 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
 
+  packages/test-compact:
+    dependencies:
+      '@huggingface/prettier-plugin-vertical-align':
+        specifier: workspace:*
+        version: link:../prettier-plugin-vertical-align
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.7.4
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+
   packages/test-groups:
     dependencies:
       '@huggingface/prettier-plugin-vertical-align':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "packages/prettier-plugin-vertical-align"
   - "packages/test"
   - "packages/test-groups"
+  - "packages/test-compact"


### PR DESCRIPTION
Add a compacted vertical alignement mode that can be used for large file containing redundant function calls.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core printing behavior and introduces new AST scanning/formatting paths, which could cause unexpected formatting regressions or performance issues on large files when patterns are enabled.
> 
> **Overview**
> Adds a new *compact mode* to `@huggingface/prettier-plugin-vertical-align` that detects call expressions matching user-supplied regex patterns, prints them on a single line, and (when consecutive) aligns callee/argument columns across the group.
> 
> The printer now scans `Program`/`BlockStatement` bodies to compute per-group alignment metadata, skips compacting when comments or block-bodied function arguments are present, and avoids interfering with other custom alignment while inside compact printing. New Prettier options `compactFunctionCallPatterns` and `compactFunctionCallMaxArgs` are introduced, along with a new `packages/test-compact` workspace package demonstrating/validating the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2a1cd4dd214ee89e4f2f6f75a326a1aea9aecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->