### PR TITLE
Stop oscillating between two formattings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.pnpm-store

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ const x = {
 	group4: "b", // new group due to multiline value above 
 };
 ```
+
+Only values that are always printed on several lines start a new group (an object written over several lines, a function body, a multiline template literal, ...). A value that ends up on several lines only because the line is too long keeps its group: whether it fits depends on the padding that was just added, so using it would make the formatting oscillate between two states on every run.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ interface Foo {
 }
 ```
 
+## Formatting
+
+Everything is printed by prettier: the plugin only widens the `:` separating a key from its value, so a line
+that has no space to add - an object whose keys all have the same length, for instance - is formatted exactly
+like prettier would. Formatting is idempotent: running the plugin on an already formatted file never changes
+it again.
+
 ## Installation
 
 Add `plugins: ["@huggingface/prettier-plugin-vertical-align"]` to your `.prettierrc` file.
@@ -60,10 +67,10 @@ const x = {
 	group2bbbb: "b",
 
 	group3:   "a",
-	group3bb: { 
+	group3bb: {
 		x: 1,
 	},
-	group4: "b", // new group due to multiline value above 
+	group4: "b", // new group due to multiline value above
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"keywords": [],
 	"author": "",
 	"license": "ISC",
-	"dependencies": {
+	"devDependencies": {
 		"prettier": "^3.3.3",
 		"typescript": "^5.6.2"
 	},

--- a/packages/prettier-plugin-vertical-align/package.json
+++ b/packages/prettier-plugin-vertical-align/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@huggingface/prettier-plugin-vertical-align",
 	"packageManager": "pnpm@9.11.0",
-	"version": "0.2.4",
+	"version": "0.3.0",
 	"description": "",
 	"scripts": {
 		"test": "pnpm -w test",

--- a/packages/prettier-plugin-vertical-align/package.json
+++ b/packages/prettier-plugin-vertical-align/package.json
@@ -19,6 +19,9 @@
 	"keywords": [],
 	"author": "",
 	"license": "ISC",
+	"peerDependencies": {
+		"prettier": "^3.0.0"
+	},
 	"devDependencies": {
 		"prettier": "^3.3.3",
 		"typescript": "^5.6.2",

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -1,4 +1,5 @@
 import type { AstPath, Doc, Printer } from "prettier";
+import type { builders } from "prettier/doc";
 import { getOriginalPrinter } from "./original-printer.js";
 
 type Node = AstPath["node"];
@@ -132,33 +133,40 @@ function addPaddingAfterColon(doc: Doc, padding: number): Doc {
 	const spaces = " ".repeat(padding);
 
 	// The separator is a part of its own in the doc of a property: `[key, ":", " ", value]` for an object
-	// property, `[key, [": ", type]]` for an interface member, ...
-	function patch(parts: Doc[]): Doc[] | undefined {
-		for (const [index, part] of parts.entries()) {
-			if (part === ":" || part === ": ") {
-				const patched = [...parts];
-				patched[index] = `:${spaces}${part.slice(1)}`;
-				return patched;
-			}
-			if (Array.isArray(part)) {
-				const patchedPart = patch(part);
-				if (patchedPart) {
-					const patched = [...parts];
-					patched[index] = patchedPart;
+	// property, `[key, [": ", type]]` for an interface member, `group([group([key, [": ", type]]), " =", value])`
+	// for a class property with an initializer, ... The first one we find is the one after the key, as the key
+	// is printed before it.
+	function patch(part: Doc): Doc | undefined {
+		if (part === ":" || part === ": ") {
+			return `:${spaces}${part.slice(1)}`;
+		}
+
+		if (Array.isArray(part)) {
+			for (const [index, child] of part.entries()) {
+				const patchedChild = patch(child);
+				if (patchedChild !== undefined) {
+					const patched = [...part];
+					patched[index] = patchedChild;
 					return patched;
 				}
+			}
+			return;
+		}
+
+		if (isPatchableGroup(part)) {
+			const patchedContents = patch(part.contents);
+			if (patchedContents !== undefined) {
+				return { ...part, contents: patchedContents };
 			}
 		}
 	}
 
-	if (Array.isArray(doc)) {
-		return patch(doc) ?? doc;
-	}
-	if (typeof doc === "object" && doc.type === "group" && Array.isArray(doc.contents)) {
-		const patched = patch(doc.contents);
-		return patched ? { ...doc, contents: patched } : doc;
-	}
-	return doc;
+	return patch(doc) ?? doc;
+}
+
+/** Conditional groups are left alone: their `expandedStates` hold other copies of the same doc. */
+function isPatchableGroup(doc: Doc): doc is builders.Group {
+	return typeof doc === "object" && !Array.isArray(doc) && doc.type === "group" && !doc.expandedStates;
 }
 
 /**
@@ -245,8 +253,12 @@ function hasBlankLineBetween(a: Node, b: Node, options: { originalText: string }
  * used to make layout decisions, otherwise the decision depends on the previous run's output.
  */
 function forcesBreak(prop: Node, options: { originalText: string }): boolean {
-	const value = isProperty(prop) ? prop[valueField(prop)] : prop;
-	return value ? subtreeForcesBreak(value, options) : false;
+	if (!isProperty(prop)) {
+		return subtreeForcesBreak(prop, options);
+	}
+
+	// A class property is `key: Type = initializer`: both sides can be printed on several lines
+	return subtreeForcesBreak(prop.value, options) || subtreeForcesBreak(prop.typeAnnotation, options);
 }
 
 const OBJECT_LIKE = new Set([

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -42,7 +42,7 @@ export const printer: Printer = {
 			// The container is only aligned if it is printed on multiple lines. Prettier decides that from the
 			// presence of a newline between the "{" and the first member in the *original* text, so this
 			// predicate is stable under re-formatting.
-			if (properties.length && !hasNewlineBeforeFirstMember(node, properties[0], options)) {
+			if (properties.length && !isExpanded(node, properties, options)) {
 				return getOriginalPrinter().print(path, options, _print, ...args);
 			}
 
@@ -226,10 +226,12 @@ function endWithComments(node: Node): number {
 	return node.comments?.length ? Math.max(nodeEnd(node), ...node.comments.map(nodeEnd)) : nodeEnd(node);
 }
 
-function hasNewlineBeforeFirstMember(container: Node, firstMember: Node, options: { originalText: string }) {
-	return options.originalText
-		.slice(nodeStart(container), startWithComments(firstMember))
-		.includes("\n");
+/**
+ * Whether prettier prints this object-like node on several lines: it does so when there is a newline between
+ * the "{" and the first member in the original text - comments on the "{" line do not count.
+ */
+function isExpanded(container: Node, members: Node[], options: { originalText: string }) {
+	return members.length > 0 && options.originalText.slice(nodeStart(container), nodeStart(members[0])).includes("\n");
 }
 
 function hasBlankLineBetween(a: Node, b: Node, options: { originalText: string }) {
@@ -256,6 +258,33 @@ const OBJECT_LIKE = new Set([
 	"RecordExpression",
 ]);
 
+/**
+ * Prettier always breaks an array of at least two object or array literals having more than one member.
+ */
+function isAlwaysBrokenArray(node: Node) {
+	if (node.type !== "ArrayExpression" && node.type !== "TupleExpression") {
+		return false;
+	}
+
+	return (
+		node.elements.length > 1 &&
+		node.elements.every(
+			(element: Node) =>
+				(element?.type === "ObjectExpression" && element.properties.length > 1) ||
+				((element?.type === "ArrayExpression" || element?.type === "TupleExpression") && element.elements.length > 1),
+		)
+	);
+}
+
+/** A comment written on its own line stays on its own line, a trailing one does not break anything. */
+function isOwnLineComment(comment: Node, options: { originalText: string }) {
+	const before = options.originalText.slice(0, nodeStart(comment));
+	return (
+		/\n[^\S\n]*$/.test(before) ||
+		options.originalText.slice(nodeStart(comment), nodeEnd(comment)).includes("\n")
+	);
+}
+
 function subtreeForcesBreak(node: Node, options: { originalText: string }): boolean {
 	if (!node || typeof node !== "object") {
 		return false;
@@ -266,19 +295,21 @@ function subtreeForcesBreak(node: Node, options: { originalText: string }): bool
 	if (!node.type) {
 		return false;
 	}
-	if (node.comments?.length) {
+	if (node.comments?.some((comment: Node) => isOwnLineComment(comment, options))) {
 		return true;
 	}
-	if (OBJECT_LIKE.has(node.type)) {
-		const members = node.properties ?? node.body ?? node.members ?? [];
-		if (members.length && hasNewlineBeforeFirstMember(node, members[0], options)) {
-			return true;
-		}
+	if (OBJECT_LIKE.has(node.type) && isExpanded(node, node.properties ?? node.body ?? node.members ?? [], options)) {
+		return true;
+	}
+	if (isAlwaysBrokenArray(node)) {
+		return true;
 	}
 	if (node.type === "BlockStatement" && node.body?.length) {
 		return true;
 	}
-	if (node.type === "TemplateLiteral" && options.originalText.slice(nodeStart(node), nodeEnd(node)).includes("\n")) {
+	// Only the literal parts of a template are kept as they are written: a newline anywhere else comes from a
+	// nested node, which is checked on its own below.
+	if (node.type === "TemplateLiteral" && node.quasis?.some((quasi: Node) => quasi.value?.raw?.includes("\n"))) {
 		return true;
 	}
 	for (const key of Object.keys(node)) {

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -10,14 +10,77 @@ type Node = AstPath["node"];
 const keyLengthSymbol = Symbol("keyLength");
 const typeAnnotationPrefix = Symbol("typeAnnotation");
 
-function shouldMoveCompletelyToNextLine(node: Node) {
-	return node.type === "LogicalExpression";
+/**
+ * Mirrors prettier's own `shouldBreakAfterOperator` (src/language-js/print/assignment.js): those are the
+ * values that prettier moves to the line below the `:` when the property does not fit.
+ *
+ * It must only depend on the AST and on the options, never on how the value happens to be laid out in the
+ * input, otherwise formatting is not idempotent.
+ */
+function shouldMoveCompletelyToNextLine(value: Node, keyLength: number, options: { tabWidth: number }): boolean {
+	if (!value) {
+		return false;
+	}
 
-	// Alternative implementation:
-	// return node.value.type !== "ObjectExpression" &&
-	//   node.value.type !== "ArrayExpression" &&
-	//   node.value.type !== "CallExpression" &&
-	//   node.value.type !== "AwaitExpression";
+	if (isBinaryish(value) && !shouldInlineLogicalExpression(value)) {
+		return true;
+	}
+
+	switch (value.type) {
+		case "StringLiteralTypeAnnotation":
+		case "SequenceExpression":
+			return true;
+		case "TSConditionalType":
+		case "ConditionalExpression": {
+			const { test } = value;
+			return isBinaryish(test) && !shouldInlineLogicalExpression(test);
+		}
+		case "ClassExpression":
+			return !!value.decorators?.length;
+	}
+
+	// Prettier keeps the value on the same line when the key is short
+	if (keyLength <= options.tabWidth) {
+		return false;
+	}
+
+	let node = value;
+	while (node.type === "UnaryExpression" || node.type === "TSNonNullExpression") {
+		node = node.argument ?? node.expression;
+	}
+
+	return isStringLiteral(node) || isMemberExpressionChain(node);
+}
+
+function isBinaryish(node: Node) {
+	return node?.type === "BinaryExpression" || node?.type === "LogicalExpression";
+}
+
+function shouldInlineLogicalExpression(node: Node) {
+	if (node.type !== "LogicalExpression") {
+		return false;
+	}
+	if (node.right.type === "ObjectExpression" && node.right.properties.length > 0) {
+		return true;
+	}
+	if (node.right.type === "ArrayExpression" && node.right.elements.length > 0) {
+		return true;
+	}
+	return false;
+}
+
+function isStringLiteral(node: Node) {
+	return node?.type === "StringLiteral" || (node?.type === "Literal" && typeof node.value === "string");
+}
+
+function isMemberExpressionChain(node: Node): boolean {
+	if (node?.type !== "MemberExpression" && node?.type !== "OptionalMemberExpression") {
+		return false;
+	}
+	if (node.object.type === "Identifier") {
+		return true;
+	}
+	return isMemberExpressionChain(node.object);
 }
 
 export const printer: Printer = {
@@ -54,7 +117,7 @@ export const printer: Printer = {
 						path.call(_print, "key"),
 						node.computed ? "]" : "",
 						":" + " ".repeat(addedLength + 1),
-						shouldMoveCompletelyToNextLine(node[valueField(node)])
+						shouldMoveCompletelyToNextLine(node[valueField(node)], keyLength, options)
 							? ifBreak(indent(group([line, path.call(_print, valueField(node))])), path.call(_print, valueField(node)))
 							: path.call(_print, valueField(node)),
 					]);
@@ -75,23 +138,24 @@ export const printer: Printer = {
 
 		if (isPropertyContainer(node)) {
 			let groups: Node[][] = [];
-			let prevLine = -Infinity;
 
 			// console.log("node", node);
 			// console.log("node", inspect(node, {depth: 10}));
-			const properties: Node[] = nodeProperties(node).filter((node: Node) =>
-				!isProperty(node) || !node[valueField(node)]?.loc
-					? node.loc.start.line === node.loc.end.line
-					: node.key.loc.start.line === node[valueField(node)].loc.start.line,
-			);
+			const properties: Node[] = nodeProperties(node);
 
+			// The container is only aligned if it is printed on multiple lines. Prettier decides that from the
+			// presence of a newline between the "{" and the first member in the *original* text, so this
+			// predicate is stable under re-formatting.
+			if (properties.length && !hasNewlineBeforeFirstMember(node, properties[0], options)) {
+				return getOriginalPrinter().print(path, options, _print, ...args);
+			}
+
+			let prev: Node | undefined;
 			for (const prop of properties) {
-				const propStart = prop.comments ? prop.comments[0].loc.start.line : prop.loc.start.line;
-				if (prevLine === propStart) {
-					// Multiple properties on the same line
-					return getOriginalPrinter().print(path, options, _print, ...args);
-				}
-				if (prevLine === -Infinity || (options.alignInGroups === "always" && prevLine !== propStart - 1)) {
+				if (
+					!prev ||
+					(options.alignInGroups === "always" && (hasBlankLineBetween(prev, prop, options) || forcesBreak(prev, options)))
+				) {
 					groups.push([]);
 				}
 
@@ -100,7 +164,7 @@ export const printer: Printer = {
 					groups.at(-1)!.push(prop);
 				}
 
-				prevLine = prop.loc.start.line;
+				prev = prop;
 			}
 
 			for (const group of groups.filter((group) => group.length > 1)) {
@@ -174,4 +238,83 @@ function modifierLength(node: AstPath["node"]) {
 		(node.declare ? "declare ".length : 0) +
 		(node.readonly ? "readonly ".length : 0)
 	);
+}
+
+function nodeStart(node: Node): number {
+	return node.range?.[0] ?? node.start;
+}
+function nodeEnd(node: Node): number {
+	return node.range?.[1] ?? node.end;
+}
+function startWithComments(node: Node): number {
+	return node.comments?.length ? Math.min(nodeStart(node), ...node.comments.map(nodeStart)) : nodeStart(node);
+}
+function endWithComments(node: Node): number {
+	return node.comments?.length ? Math.max(nodeEnd(node), ...node.comments.map(nodeEnd)) : nodeEnd(node);
+}
+
+function hasNewlineBeforeFirstMember(container: Node, firstMember: Node, options: { originalText: string }) {
+	return options.originalText
+		.slice(nodeStart(container), startWithComments(firstMember))
+		.includes("\n");
+}
+
+function hasBlankLineBetween(a: Node, b: Node, options: { originalText: string }) {
+	const between = options.originalText.slice(endWithComments(a), startWithComments(b));
+	return (between.match(/\n/g)?.length ?? 0) > 1;
+}
+
+/**
+ * Whether this property is guaranteed to be printed on several lines, whatever the print width is.
+ * Only *forced* breaks are taken into account: a break caused by the line being too long must not be
+ * used to make layout decisions, otherwise the decision depends on the previous run's output.
+ */
+function forcesBreak(prop: Node, options: { originalText: string }): boolean {
+	const value = isProperty(prop) ? prop[valueField(prop)] : prop;
+	return value ? subtreeForcesBreak(value, options) : false;
+}
+
+const OBJECT_LIKE = new Set([
+	"ObjectExpression",
+	"ObjectPattern",
+	"TSTypeLiteral",
+	"TSInterfaceBody",
+	"ClassBody",
+	"RecordExpression",
+]);
+
+function subtreeForcesBreak(node: Node, options: { originalText: string }): boolean {
+	if (!node || typeof node !== "object") {
+		return false;
+	}
+	if (Array.isArray(node)) {
+		return node.some((child) => subtreeForcesBreak(child, options));
+	}
+	if (!node.type) {
+		return false;
+	}
+	if (node.comments?.length) {
+		return true;
+	}
+	if (OBJECT_LIKE.has(node.type)) {
+		const members = node.properties ?? node.body ?? node.members ?? [];
+		if (members.length && hasNewlineBeforeFirstMember(node, members[0], options)) {
+			return true;
+		}
+	}
+	if (node.type === "BlockStatement" && node.body?.length) {
+		return true;
+	}
+	if (node.type === "TemplateLiteral" && options.originalText.slice(nodeStart(node), nodeEnd(node)).includes("\n")) {
+		return true;
+	}
+	for (const key of Object.keys(node)) {
+		if (key === "loc" || key === "range" || key === "parent" || key === "tokens") {
+			continue;
+		}
+		if (subtreeForcesBreak(node[key], options)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/prettier-plugin-vertical-align/src/printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/printer.ts
@@ -1,87 +1,10 @@
-import type { AstPath, Printer } from "prettier";
-import prettier from "prettier";
-// import { inspect } from "node:util";
-const { doc } = prettier;
+import type { AstPath, Doc, Printer } from "prettier";
 import { getOriginalPrinter } from "./original-printer.js";
 
-const { group, softline, line, ifBreak, indent } = doc.builders;
-
 type Node = AstPath["node"];
-const keyLengthSymbol = Symbol("keyLength");
-const typeAnnotationPrefix = Symbol("typeAnnotation");
 
-/**
- * Mirrors prettier's own `shouldBreakAfterOperator` (src/language-js/print/assignment.js): those are the
- * values that prettier moves to the line below the `:` when the property does not fit.
- *
- * It must only depend on the AST and on the options, never on how the value happens to be laid out in the
- * input, otherwise formatting is not idempotent.
- */
-function shouldMoveCompletelyToNextLine(value: Node, keyLength: number, options: { tabWidth: number }): boolean {
-	if (!value) {
-		return false;
-	}
-
-	if (isBinaryish(value) && !shouldInlineLogicalExpression(value)) {
-		return true;
-	}
-
-	switch (value.type) {
-		case "StringLiteralTypeAnnotation":
-		case "SequenceExpression":
-			return true;
-		case "TSConditionalType":
-		case "ConditionalExpression": {
-			const { test } = value;
-			return isBinaryish(test) && !shouldInlineLogicalExpression(test);
-		}
-		case "ClassExpression":
-			return !!value.decorators?.length;
-	}
-
-	// Prettier keeps the value on the same line when the key is short
-	if (keyLength <= options.tabWidth) {
-		return false;
-	}
-
-	let node = value;
-	while (node.type === "UnaryExpression" || node.type === "TSNonNullExpression") {
-		node = node.argument ?? node.expression;
-	}
-
-	return isStringLiteral(node) || isMemberExpressionChain(node);
-}
-
-function isBinaryish(node: Node) {
-	return node?.type === "BinaryExpression" || node?.type === "LogicalExpression";
-}
-
-function shouldInlineLogicalExpression(node: Node) {
-	if (node.type !== "LogicalExpression") {
-		return false;
-	}
-	if (node.right.type === "ObjectExpression" && node.right.properties.length > 0) {
-		return true;
-	}
-	if (node.right.type === "ArrayExpression" && node.right.elements.length > 0) {
-		return true;
-	}
-	return false;
-}
-
-function isStringLiteral(node: Node) {
-	return node?.type === "StringLiteral" || (node?.type === "Literal" && typeof node.value === "string");
-}
-
-function isMemberExpressionChain(node: Node): boolean {
-	if (node?.type !== "MemberExpression" && node?.type !== "OptionalMemberExpression") {
-		return false;
-	}
-	if (node.object.type === "Identifier") {
-		return true;
-	}
-	return isMemberExpressionChain(node.object);
-}
+/** Number of spaces to add after the ":" of a property, set by the printer of its parent. */
+const paddingSymbol = Symbol("padding");
 
 export const printer: Printer = {
 	print(path, options, _print, ...args) {
@@ -102,38 +25,11 @@ export const printer: Printer = {
 		//   console.log("node", inspect(node.body, { depth: 10 }));
 		// }
 
-		if (node[keyLengthSymbol]) {
-			const keyLength = node[keyLengthSymbol];
-			const addedLength = keyLength - (node.key.loc.end.column - node.key.loc.start.column) - modifierLength(node);
-
-			// console.log("keyLength", keyLength);
-
-			switch (node.type) {
-				case "Property":
-				case "ObjectProperty": {
-					// console.log(node.value.type);
-					return group([
-						node.computed ? "[" : "",
-						path.call(_print, "key"),
-						node.computed ? "]" : "",
-						":" + " ".repeat(addedLength + 1),
-						shouldMoveCompletelyToNextLine(node[valueField(node)], keyLength, options)
-							? ifBreak(indent(group([line, path.call(_print, valueField(node))])), path.call(_print, valueField(node)))
-							: path.call(_print, valueField(node)),
-					]);
-				}
-				case "PropertyDefinition":
-				case "TSPropertySignature":
-					node.typeAnnotation[typeAnnotationPrefix] = addedLength;
-					return getOriginalPrinter().print(path, options, _print, ...args);
-				default:
-					throw new Error(`Unexpected node type: ${node.type}`);
-			}
-		}
-
-		if (node[typeAnnotationPrefix]) {
-			const addedLength = node[typeAnnotationPrefix];
-			return group([": " + " ".repeat(addedLength), path.call(_print, "typeAnnotation")]);
+		const padding = node[paddingSymbol];
+		if (padding) {
+			// Let prettier print the property - so that the key, the quotes around it and the layout of the value
+			// are exactly the ones prettier would use - and only widen the ":" separator of the doc it returns.
+			return addPaddingAfterColon(getOriginalPrinter().print(path, options, _print, ...args), padding);
 		}
 
 		if (isPropertyContainer(node)) {
@@ -167,17 +63,16 @@ export const printer: Printer = {
 				prev = prop;
 			}
 
+			const quoteEveryKey = needsQuoteProps(properties, options);
+
 			for (const group of groups.filter((group) => group.length > 1)) {
-				let keyLength = 0;
-				for (const property of group) {
-					keyLength = Math.max(
-						keyLength,
-						property.key.loc.end.column - property.key.loc.start.column + modifierLength(property),
-					);
-				}
+				const keyLengths = new Map<Node, number>(
+					group.map((property) => [property, keyLength(property, options, quoteEveryKey)]),
+				);
+				const alignedLength = Math.max(...keyLengths.values());
 
 				for (const property of group) {
-					property[keyLengthSymbol] = keyLength;
+					property[paddingSymbol] = alignedLength - keyLengths.get(property)!;
 				}
 			}
 		}
@@ -226,6 +121,84 @@ function valueField(node: AstPath["node"]) {
 		return "typeAnnotation";
 	}
 	throw new Error(`Unexpected node type: ${node.type}`);
+}
+
+/**
+ * Widens the ":" separating the key from the value in the doc prettier printed for a property, which is the
+ * only thing this plugin changes. Prettier trims the trailing spaces of a line, so the padding disappears by
+ * itself when the value is moved below the ":".
+ */
+function addPaddingAfterColon(doc: Doc, padding: number): Doc {
+	const spaces = " ".repeat(padding);
+
+	// The separator is a part of its own in the doc of a property: `[key, ":", " ", value]` for an object
+	// property, `[key, [": ", type]]` for an interface member, ...
+	function patch(parts: Doc[]): Doc[] | undefined {
+		for (const [index, part] of parts.entries()) {
+			if (part === ":" || part === ": ") {
+				const patched = [...parts];
+				patched[index] = `:${spaces}${part.slice(1)}`;
+				return patched;
+			}
+			if (Array.isArray(part)) {
+				const patchedPart = patch(part);
+				if (patchedPart) {
+					const patched = [...parts];
+					patched[index] = patchedPart;
+					return patched;
+				}
+			}
+		}
+	}
+
+	if (Array.isArray(doc)) {
+		return patch(doc) ?? doc;
+	}
+	if (typeof doc === "object" && doc.type === "group" && Array.isArray(doc.contents)) {
+		const patched = patch(doc.contents);
+		return patched ? { ...doc, contents: patched } : doc;
+	}
+	return doc;
+}
+
+/**
+ * The width of the key as prettier will print it: `quoteProps` can add or remove the quotes around it, and we
+ * have to align on what is printed, not on what was written.
+ */
+function keyLength(property: Node, options: { quoteProps?: string }, quoteEveryKey: boolean) {
+	const { key } = property;
+	const modifiers = modifierLength(property);
+
+	if (!property.computed) {
+		if (isStringKey(key)) {
+			if (!quoteEveryKey && options.quoteProps !== "preserve" && isIdentifierName(key.value)) {
+				return key.value.length + modifiers;
+			}
+		} else if (quoteEveryKey && key.type === "Identifier") {
+			return key.name.length + '""'.length + modifiers;
+		}
+	}
+
+	return key.loc.end.column - key.loc.start.column + modifiers;
+}
+
+/** Prettier's `quoteProps: "consistent"`: one key needing quotes means every key is quoted. */
+function needsQuoteProps(properties: Node[], options: { quoteProps?: string }) {
+	return (
+		options.quoteProps === "consistent" &&
+		properties.some(
+			(property) =>
+				isProperty(property) && !property.computed && isStringKey(property.key) && !isIdentifierName(property.key.value),
+		)
+	);
+}
+
+function isStringKey(key: Node) {
+	return key?.type === "StringLiteral" || (key?.type === "Literal" && typeof key.value === "string");
+}
+
+function isIdentifierName(value: string) {
+	return /^(?:[$_\p{ID_Start}])(?:[$\u200C\u200D\p{ID_Continue}])*$/u.test(value);
 }
 
 function modifierLength(node: AstPath["node"]) {

--- a/packages/test-groups/src/index.ts
+++ b/packages/test-groups/src/index.ts
@@ -17,3 +17,18 @@ const x = {
 	},
 	group4: "b",
 };
+
+// A value that is only broken over several lines because the line is too long does not start a new group:
+// it would fit again as soon as the group is narrower, and the formatting would oscillate.
+declare function isSet(value: unknown): boolean;
+declare const o: Record<string, any>;
+
+const widthBreakKeepsTheGroup = {
+	repository: isSet(o.repository)
+		? Repository.fromJSON(o.repository)
+		: undefined,
+	paths:      Array.isArray(o?.paths)
+		? o.paths.map((e: any) => Buffer.from(e))
+		: [],
+	limit:      isSet(o.limit) ? Number(o.limit) : 0,
+};

--- a/packages/test-groups/src/index.ts
+++ b/packages/test-groups/src/index.ts
@@ -32,3 +32,12 @@ const widthBreakKeepsTheGroup = {
 		: [],
 	limit:      isSet(o.limit) ? Number(o.limit) : 0,
 };
+
+class GroupsOfFields {
+	// A multiline initializer ends the group, like a multiline value does
+	a: Foo = {
+		x: 1,
+	};
+	bbbbbb: number = 3;
+	cc:     number = 4;
+}

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,8 +5,8 @@
 	"main": "index.js",
 	"scripts": {
 		"format:check": "prettier --check",
-		"test": "prettier --check src/index.ts src/test.js && ./test-parser.sh",
-		"test:write": "prettier --write src/index.ts src/test.js && ./test-parser.sh"
+		"test": "prettier --check src/index.ts src/test.js stability.mjs && ./test-parser.sh && node stability.mjs",
+		"test:write": "prettier --write src/index.ts src/test.js stability.mjs && ./test-parser.sh && node stability.mjs"
 	},
 	"private": true,
 	"dependencies": {

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -124,3 +124,11 @@ const alignmentIsStable = {
 		aLongCondition && anotherConditionThatMakesTheLineTooLongForTheWidth,
 	aVeryMuchLongerKey: 1,
 };
+
+// Class properties with an initializer are aligned too: the ":" prettier prints for them is nested in the
+// group of the "key: Type" part of the assignment.
+class WithInitializers {
+	a:      Foo = 1;
+	bbbbbb: number = 3;
+	cc:     number = 4;
+}

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -113,3 +113,14 @@ class XClass extends Base {
 	// @ts-expect-error implicity-any
 	z;
 }
+
+// Used to oscillate: the padding pushes the value over the print width, prettier moves the value to the
+// next line, and on the next run the property is not detected as alignable anymore.
+declare const aLongCondition: boolean;
+declare const anotherConditionThatMakesTheLineTooLongForTheWidth: boolean;
+
+const alignmentIsStable = {
+	key:
+		aLongCondition && anotherConditionThatMakesTheLineTooLongForTheWidth,
+	aVeryMuchLongerKey: 1,
+};

--- a/packages/test/stability.mjs
+++ b/packages/test/stability.mjs
@@ -74,6 +74,10 @@ function random(max) {
 	return Math.floor((((t ^ (t >>> 14)) >>> 0) / 0x100000000) * max);
 }
 const pick = (values) => values[random(values.length)];
+// when set, every generated key has exactly this length, whatever the nesting level
+let fixedKeyLength = 0;
+const key = (index) =>
+	`${name(fixedKeyLength ? fixedKeyLength - 1 : 1 + random(14))}k${index}`;
 const name = (length) => "a".repeat(Math.max(1, length));
 
 function randomValue(budget) {
@@ -128,7 +132,7 @@ function randomValue(budget) {
 		case "object": {
 			let object = "{\n";
 			for (let i = 0; i < 2 + random(3); i++) {
-				object += `\tk${name(random(14))}: ${randomValue(b - 20)},\n`;
+				object += `\t${key(i)}: ${randomValue(b - 20)},\n`;
 			}
 			return `${object}}`;
 		}
@@ -139,10 +143,11 @@ function randomValue(budget) {
  * Objects with random key lengths and values, at random indentation levels: some of them land exactly on the
  * print width limit, which is where the plugin used to oscillate.
  */
-function randomObject() {
+function randomObject(keyLength = 0) {
+	fixedKeyLength = keyLength;
 	let text = "const x = {\n";
 	for (let i = 0; i < 2 + random(5); i++) {
-		text += `\tk${name(random(18))}: ${randomValue(60 + random(50))},\n`;
+		text += `\t${key(i)}: ${randomValue(60 + random(50))},\n`;
 	}
 	text += "};\n";
 
@@ -177,11 +182,74 @@ async function checkGeneratedObjects() {
 	}
 }
 
+/**
+ * When every key of an object has the same length, we have no space to add anywhere: the output must then be
+ * exactly the one of prettier. More generally, a property that needs no padding is printed by prettier
+ * itself, so that we only ever change the lines we have something to add to.
+ */
+async function checkGeneratedObjectsMatchPrettier() {
+	seed = 0x5678;
+	for (let i = 0; i < 400 && failures.length < 5; i++) {
+		const text = randomObject(3 + random(18));
+		const options = {
+			parser:     "typescript",
+			printWidth: 120,
+			tabWidth:   2,
+			useTabs:    true,
+		};
+		const expected = await prettier.format(text, options);
+		const actual = await prettier.format(text, {
+			...options,
+			plugins: ["@huggingface/prettier-plugin-vertical-align"],
+		});
+
+		if (expected !== actual) {
+			failures.push(
+				`generated object #${i} has keys of the same length but is not formatted like prettier:\n${text}\n--- prettier ---\n${expected}--- with the plugin ---\n${actual}`,
+			);
+		}
+	}
+}
+
+/**
+ * Sources whose keys are not printed the way they are written: `quoteProps` adds or removes the quotes, so
+ * the padding has to be computed on the printed key, otherwise the file changes again on the next run.
+ */
+async function checkQuotedKeys() {
+	const cases = [
+		// prettier removes the quotes it does not need
+		{ source: `const x = {\n\t"aaa": 1,\n\t"b": 2,\n};\n`, options: {} },
+		// one key needs quotes, so prettier quotes all of them
+		{
+			source:  `const x = {\n\t"a-b": 1,\n\taaa: 2,\n\tb: 3,\n};\n`,
+			options: { quoteProps: "consistent" },
+		},
+		// the quotes are kept as they are written
+		{
+			source:  `const x = {\n\t"aaa": 1,\n\tb: 2,\n};\n`,
+			options: { quoteProps: "preserve" },
+		},
+	];
+
+	for (const [index, { source, options }] of cases.entries()) {
+		await checkStable(`quoted keys #${index}\n${source}`, source, {
+			parser:     "typescript",
+			plugins:    ["@huggingface/prettier-plugin-vertical-align"],
+			printWidth: 120,
+			tabWidth:   2,
+			useTabs:    true,
+			...options,
+		});
+	}
+}
+
 await checkFixtures();
+await checkQuotedKeys();
 await checkGeneratedObjects();
+await checkGeneratedObjectsMatchPrettier();
 
 if (failures.length) {
-	console.error(`Formatting is not stable:\n\n${failures.join("\n\n")}`);
+	console.error(`${failures.join("\n\n")}`);
 	process.exit(1);
 }
 

--- a/packages/test/stability.mjs
+++ b/packages/test/stability.mjs
@@ -243,8 +243,46 @@ async function checkQuotedKeys() {
 	}
 }
 
+/**
+ * Group boundaries must only depend on breaks that always happen, whatever the print width is.
+ */
+async function checkGroupBoundaries() {
+	const cases = [
+		// a comment on the "{" line does not prevent prettier from expanding the object
+		`const x = { // hello\n\taa: 1, bbbbbb: 2 };\n`,
+		// an inline comment does not make the value multiline
+		`const x = {\n\taa: /* cast */ value,\n\tbbbbbb: 3,\n\tcc: 4,\n};\n`,
+		// neither does a trailing one
+		`const x = {\n\taa: 1, // note\n\tbbbbbb: 3,\n\tcc: 4,\n};\n`,
+		// prettier collapses this array, so it stays in the group
+		`const x = {\n\taa: [\n\t\t1,\n\t\t2,\n\t],\n\tbbbbbb: 3,\n\tcc: 4,\n};\n`,
+		// but it always breaks an array of objects, so it ends the group
+		`const x = {\n\taa: [{ a: 1, b: 2 }, { a: 3, b: 4 }],\n\tbbbbbb: 3,\n\tcc: 4,\n};\n`,
+		// a break inside a template interpolation is not a break of the property
+		`const x = {\n\tk: \`text \${fn(argumentOne, argumentTwo, argumentThree, argFour)} tail\`,\n\tkkkkkkkkkkkk: 1,\n\tkkk: 2,\n};\n`,
+	];
+
+	for (const [index, source] of cases.entries()) {
+		for (const alignInGroups of ["never", "always"]) {
+			await checkStable(
+				`group boundaries #${index} (alignInGroups: ${alignInGroups})\n${source}`,
+				source,
+				{
+					parser:     "typescript",
+					plugins:    ["@huggingface/prettier-plugin-vertical-align"],
+					printWidth: 80,
+					tabWidth:   2,
+					useTabs:    true,
+					alignInGroups,
+				},
+			);
+		}
+	}
+}
+
 await checkFixtures();
 await checkQuotedKeys();
+await checkGroupBoundaries();
 await checkGeneratedObjects();
 await checkGeneratedObjectsMatchPrettier();
 

--- a/packages/test/stability.mjs
+++ b/packages/test/stability.mjs
@@ -280,7 +280,51 @@ async function checkGroupBoundaries() {
 	}
 }
 
+/**
+ * Every kind of member must actually end up aligned: a padding we compute but fail to print is invisible in
+ * the fixtures as long as the member with the longest key is the one prettier prints unchanged.
+ */
+async function checkColumnsAreAligned() {
+	const cases = [
+		`const object = {\n\ta: 1,\n\tbbbbbb: 2,\n\tcc: 3,\n};\n`,
+		`const quoted = {\n\t"a-b": 1,\n\tbbbbbb: 2,\n\tcc: 3,\n};\n`,
+		`const computed = {\n\t[a]: 1,\n\tbbbbbb: 2,\n\tcc: 3,\n};\n`,
+		`interface Members {\n\ta: Foo;\n\tbbbbbb?: number;\n\tcc: number;\n}\n`,
+		`type Literal = {\n\ta: Foo;\n\tbbbbbb: number;\n\tcc: number;\n};\n`,
+		`class Fields {\n\ta: Foo;\n\tbbbbbb: number;\n\tcc: number;\n}\n`,
+		`class Initializers {\n\ta: Foo = 1;\n\tbbbbbb: number = 3;\n\tcc: number = 4;\n}\n`,
+		`class Modifiers {\n\tprivate a: Foo = 1;\n\tstatic readonly bbbbbb: number = 3;\n\tdeclare cc?: number;\n}\n`,
+	];
+
+	for (const source of cases) {
+		const formatted = await prettier.format(source, {
+			parser:     "typescript",
+			plugins:    ["@huggingface/prettier-plugin-vertical-align"],
+			printWidth: 120,
+			tabWidth:   2,
+			useTabs:    true,
+		});
+
+		// Every member of these sources is on a line of its own, at the same indentation, so all their values
+		// have to start at the same column
+		const columns = new Set();
+		for (const line of formatted.split("\n")) {
+			const member = /^\t+(?<key>.*?):(?<spaces> +)(?<value>\S.*)$/u.exec(line);
+			if (member) {
+				columns.add(line.length - member.groups.value.length);
+			}
+		}
+
+		if (columns.size > 1) {
+			failures.push(
+				`the members of this source are not aligned:\n${source}\n--- formatted ---\n${formatted}`,
+			);
+		}
+	}
+}
+
 await checkFixtures();
+await checkColumnsAreAligned();
 await checkQuotedKeys();
 await checkGroupBoundaries();
 await checkGeneratedObjects();

--- a/packages/test/stability.mjs
+++ b/packages/test/stability.mjs
@@ -1,0 +1,188 @@
+/**
+ * Formatting must be idempotent: formatting an already formatted file must be a no-op.
+ *
+ * This is easy to break in this plugin, because it is tempting to base alignment decisions on the way the
+ * input happens to be laid out (`node.loc`) - but the input is the output of the previous run, and the
+ * padding we add changes prettier's line breaking decisions. Such a rule makes the formatting oscillate
+ * between two states forever.
+ */
+import prettier from "prettier";
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const packagesDir = path.join(packageDir, "..");
+const failures = [];
+
+async function checkStable(name, text, options) {
+	const first = await prettier.format(text, options);
+	const second = await prettier.format(first, options);
+
+	if (first === second) {
+		return;
+	}
+
+	const third = await prettier.format(second, options);
+	const lines = first.split("\n");
+	const otherLines = second.split("\n");
+	const diff = [];
+
+	for (
+		let i = 0;
+		i < Math.max(lines.length, otherLines.length) && diff.length < 6;
+		i++
+	) {
+		if (lines[i] !== otherLines[i]) {
+			diff.push(
+				`  pass 1: ${JSON.stringify(lines[i])}\n  pass 2: ${JSON.stringify(otherLines[i])}`,
+			);
+		}
+	}
+
+	failures.push(
+		`${name} is ${third === first ? "oscillating between two states" : "not idempotent"}:\n${diff.join("\n")}`,
+	);
+}
+
+/**
+ * The committed fixtures, formatted with the config of the package they live in.
+ */
+async function checkFixtures() {
+	for (const pkg of ["test", "test-groups"]) {
+		const dir = path.join(packagesDir, pkg, "src");
+		for (const file of await readdir(dir)) {
+			const filepath = path.join(dir, file);
+			await checkStable(
+				path.relative(packagesDir, filepath),
+				await readFile(filepath, "utf8"),
+				{
+					...(await prettier.resolveConfig(filepath)),
+					filepath,
+				},
+			);
+		}
+	}
+}
+
+// mulberry32, to keep the generated cases reproducible
+let seed = 0x1234;
+function random(max) {
+	seed = (seed + 0x6d2b79f5) | 0;
+	let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+	t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+	return Math.floor((((t ^ (t >>> 14)) >>> 0) / 0x100000000) * max);
+}
+const pick = (values) => values[random(values.length)];
+const name = (length) => "a".repeat(Math.max(1, length));
+
+function randomValue(budget) {
+	const b = Math.max(4, budget);
+	switch (
+		pick([
+			"identifier",
+			"call",
+			"logical",
+			"ternary",
+			"string",
+			"template",
+			"member",
+			"arrow",
+			"await",
+			"as",
+			"binary",
+			"object",
+			"array",
+			"unary",
+			"new",
+		])
+	) {
+		case "identifier":
+			return name(b);
+		case "call":
+			return `fn${name(random(10))}(${name(random(b))}, ${name(random(10))})`;
+		case "logical":
+			return `${name(random(b))} && ${name(random(b))}`;
+		case "ternary":
+			return `${name(random(10))} ? ${name(random(b))} : ${name(random(b))}`;
+		case "string":
+			return `"${name(random(b))}"`;
+		case "template":
+			return `\`${name(random(b))}\${x}\``;
+		case "member":
+			return `${name(random(8))}.${name(random(8))}.${name(random(8))}(${name(random(8))})`;
+		case "arrow":
+			return `(${name(random(6))}) => ${name(random(b))}`;
+		case "await":
+			return `await ${name(random(8))}(${name(random(b))})`;
+		case "as":
+			return `${name(random(b))} as ${name(random(10))}`;
+		case "binary":
+			return `${name(random(b))} + ${name(random(b))}`;
+		case "unary":
+			return `!!${name(random(8))}.${name(random(b))}`;
+		case "new":
+			return `new ${name(random(8))}(${name(random(b))})`;
+		case "array":
+			return `[${name(random(b))}, ${name(random(10))}]`;
+		case "object": {
+			let object = "{\n";
+			for (let i = 0; i < 2 + random(3); i++) {
+				object += `\tk${name(random(14))}: ${randomValue(b - 20)},\n`;
+			}
+			return `${object}}`;
+		}
+	}
+}
+
+/**
+ * Objects with random key lengths and values, at random indentation levels: some of them land exactly on the
+ * print width limit, which is where the plugin used to oscillate.
+ */
+function randomObject() {
+	let text = "const x = {\n";
+	for (let i = 0; i < 2 + random(5); i++) {
+		text += `\tk${name(random(18))}: ${randomValue(60 + random(50))},\n`;
+	}
+	text += "};\n";
+
+	for (let depth = 0; depth < random(5); depth++) {
+		text = `function f${depth}() {\n${text
+			.split("\n")
+			.map((line) => (line ? `\t${line}` : line))
+			.join("\n")}}\n`;
+	}
+
+	return text;
+}
+
+async function checkGeneratedObjects() {
+	for (const alignInGroups of ["never", "always"]) {
+		seed = 0x1234;
+		for (let i = 0; i < 400 && failures.length < 5; i++) {
+			const text = randomObject();
+			await checkStable(
+				`generated object #${i} (alignInGroups: ${alignInGroups})\n${text}`,
+				text,
+				{
+					parser:     "typescript",
+					plugins:    ["@huggingface/prettier-plugin-vertical-align"],
+					printWidth: 120,
+					tabWidth:   2,
+					useTabs:    true,
+					alignInGroups,
+				},
+			);
+		}
+	}
+}
+
+await checkFixtures();
+await checkGeneratedObjects();
+
+if (failures.length) {
+	console.error(`Formatting is not stable:\n\n${failures.join("\n\n")}`);
+	process.exit(1);
+}
+
+console.log("Formatting is stable");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3


### PR DESCRIPTION
:warning: Full AI slop

Sometimes a file kept flipping between two formattings, one save after the other:

```ts
// pass 1
const x = {
	key: aLongCondition && anotherConditionThatMakesTheLineTooLongForTheWidth,
	aVeryMuchLongerKey: 1,
};

// pass 2
const x = {
	key:
		aLongCondition && anotherConditionThatMakesTheLineTooLongForTheWidth,
	aVeryMuchLongerKey: 1,
};

// pass 3 = pass 1, and so on
```

The padding we add pushes the line over `printWidth`, so prettier moves the value below the `:`. On the next
run the plugin looked at the input, saw a value that is not on its key's line, decided it was not alignable,
printed it without padding, and it fitted on one line again.

With `alignInGroups: "always"` the same loop happens through the groups: a value that only breaks because the
line is too long started a new group on the next run, the group got narrower, the value fitted again, ...
(that is what makes `server/gitaly/proto/*.ts` in moon-landing flip back and forth).

## Fix

Two things, both of which also bring the output closer to prettier's.

**Decisions come from the AST and the options, never from the line numbers of the input.** A property is
aligned even when its value currently sits below the `:` (the padding spaces are kept, prettier trims them
when it breaks the line). With `alignInGroups: "always"`, only a value that is *always* multiline (expanded
object, function body, multiline template) starts a new group. An object is aligned iff there is a newline
after its `{` in the source, which is what prettier uses to decide to expand it.

**The plugin only widens the `:`.** Properties are printed by prettier, and we add the padding spaces to the
`":"` part of the doc it returns, instead of rebuilding our own approximation of `printAssignment`. So the
layout of the value and the quoting of the key are prettier's, and a property that needs no padding is
prettier's output byte for byte. On 800 generated objects whose keys all have the same length, 82 were
formatted differently from plain prettier by 0.2.4, 0 are now.

## Numbers

- moon-landing, 1111 `.ts` files: 12 unstable files before, 0 after (`server/server.ts` still needs 2 passes,
  as it already did in 0.2.4: an object written on one line that prettier has to break is only aligned on the
  second pass).
- 3000 generated objects: 83 oscillating and 398 needing more than one pass before, 0 and 0 after.
- Lines differing from plain prettier, padding aside: 11% before, 4.5% now (the rest is the alignment itself
  making lines longer, so prettier breaks them differently).

The plugin's own fixtures are unchanged, but `alignInGroups: "always"` groups can be wider than before (a
value broken by the print width no longer splits them) and quoted keys now follow `quoteProps`, so a repo
using it should expect a one-time reformat: 254 of moon-landing's 1111 files. Hence 0.3.0.

## Tests

`packages/test/stability.mjs` formats every fixture, a few `quoteProps` cases and 800 generated objects (both
`alignInGroups` modes, seeded so it is reproducible) twice, and fails if the second pass changes anything. It
also checks that 400 generated objects whose keys all have the same length are formatted exactly like plain
prettier. Both checks fail on `main`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core formatting logic was rewritten; behavior is closer to Prettier but `alignInGroups: "always"` and quoted keys can shift output, so consumers may need a one-time reformat.
> 
> **Overview**
> Fixes **save/format loops** where padding pushed lines past `printWidth`, Prettier broke values onto the next line, and the plugin then treated those properties as non-alignable on the next pass.
> 
> The printer no longer rebuilds property layout. It delegates to Prettier and only **widens the `:`** in the returned doc (`addPaddingAfterColon`). Alignment and `alignInGroups` boundaries use **stable rules** from the AST and `originalText`—expanded objects (`isExpanded`), blank lines, and values that **always** break (`forcesBreak`)—not whether a value currently sits on the same line as its key. Key width respects **`quoteProps`** so padding matches printed keys.
> 
> Releases **0.3.0** with `prettier` as a **peerDependency**, documents idempotent formatting in the README, and adds **`stability.mjs`** (double-format checks on fixtures, generated objects, `quoteProps`, and group boundaries) wired into the test package scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d940f3d56111b65b14743050aa9a4fa8223e890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->