### PR TITLE
Fix stack overflow on range-format

### DIFF
--- a/packages/prettier-plugin-vertical-align/src/original-printer.ts
+++ b/packages/prettier-plugin-vertical-align/src/original-printer.ts
@@ -2,7 +2,16 @@ import type { Printer } from "prettier";
 
 let originalPrinter: Printer;
 
+/// `wrapParser.preprocess` installs the plugin by replacing `options.printer` with a merged object
+/// whose `print` is ours. Prettier runs `preprocess` more than once per format (range-format and
+/// option-normalization both re-enter it); the second call would capture the already-installed plugin
+/// printer as the "original", making `getOriginalPrinter().print` re-enter our own `print` for the
+/// root node forever (RangeError: Maximum call stack size exceeded). The real printer is always the
+/// first one prettier hands us, so keep it.
 export function setOriginalPrinter(printer: Printer) {
+  if (originalPrinter) {
+    return;
+  }
   originalPrinter = printer;
 }
 

--- a/packages/test/stability.mjs
+++ b/packages/test/stability.mjs
@@ -323,12 +323,74 @@ async function checkColumnsAreAligned() {
 	}
 }
 
+/**
+ * Range-formatting (`rangeStart`/`rangeEnd`) must not crash. Prettier runs `preprocess` more than
+ * once for a range format, and a second `setOriginalPrinter` call used to capture the plugin's own
+ * printer, making `getOriginalPrinter().print` re-enter the plugin's `print` for the root node until
+ * the stack overflowed. The formatted output of a range covering the whole file must equal the
+ * full-file output.
+ */
+async function checkRangeFormatting() {
+	const sources = [
+		`const object = {\n\ta: 1,\n\tbbbbbb: 2,\n\tcc: 3,\n};\n`,
+		`interface X {\n\ta:  string;\n\tbc: number;\n}\n`,
+		`const x = {\n\ta:  1,\n\tbc: {\n\t\tx: 1,\n\t},\n};\n`,
+	];
+	for (const [index, source] of sources.entries()) {
+		for (const alignInGroups of ["never", "always"]) {
+			const options = {
+				parser:     "typescript",
+				plugins:    ["@huggingface/prettier-plugin-vertical-align"],
+				printWidth: 120,
+				tabWidth:   2,
+				useTabs:    true,
+				alignInGroups,
+			};
+			let full;
+			try {
+				full = await prettier.format(source, options);
+			} catch (err) {
+				failures.push(
+					`range #${index} full-file format threw: ${err.message}\n${source}`,
+				);
+				continue;
+			}
+			// range covering the whole file, a prefix, and a suffix
+			for (const [range, [start, end]] of [
+				["full", [0, source.length]],
+				["prefix", [0, 10]],
+				["suffix", [Math.max(0, source.length - 5), source.length]],
+			]) {
+				let rangeOut;
+				try {
+					rangeOut = await prettier.format(source, {
+						...options,
+						rangeStart: start,
+						rangeEnd:   end,
+					});
+				} catch (err) {
+					failures.push(
+						`range #${index} (${range}, alignInGroups: ${alignInGroups}) threw: ${err.message}\n${source}`,
+					);
+					continue;
+				}
+				if (rangeOut !== full) {
+					failures.push(
+						`range #${index} (${range}, alignInGroups: ${alignInGroups}) differs from full-file output:\n${source}\n--- full ---\n${full}--- range ---\n${rangeOut}`,
+					);
+				}
+			}
+		}
+	}
+}
+
 await checkFixtures();
 await checkColumnsAreAligned();
 await checkQuotedKeys();
 await checkGroupBoundaries();
 await checkGeneratedObjects();
 await checkGeneratedObjectsMatchPrettier();
+await checkRangeFormatting();
 
 if (failures.length) {
 	console.error(`${failures.join("\n\n")}`);


### PR DESCRIPTION
Range-formatting (`rangeStart`/`rangeEnd`) crashed with `RangeError: Maximum call stack size exceeded`, while full-file format worked. Affected any editor that range-formats on save (e.g. Zed's `format_on_save: "modifications"`).

`setOriginalPrinter` runs more than once per format — prettier re-enters `preprocess` for range-format and option normalization. The second call captured the already-installed plugin printer as the "original", so `getOriginalPrinter().print` re-entered the plugin's own `print` for the root `Program` node infinitely. The real printer is always the first one prettier hands us, so ignore subsequent calls.

Adds a `checkRangeFormatting` regression to `stability.mjs` — confirmed it throws without the fix, passes with it.

Generated with Claude Code, acting for @Pierrci.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted guard in printer bootstrap plus regression tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Fixes **range-format** (`rangeStart`/`rangeEnd`) crashing with `RangeError: Maximum call stack size exceeded` while full-file format still worked (e.g. editors that format only modified regions on save).
> 
> **`setOriginalPrinter`** now **ignores subsequent calls** and keeps only the first printer Prettier passes in. Repeated `preprocess` during range-format and option normalization used to overwrite the stored “original” with the plugin’s merged printer, so **`getOriginalPrinter().print`** could recurse into the plugin’s own **`print`** on the root node indefinitely.
> 
> Adds **`checkRangeFormatting`** in **`stability.mjs`**: range formats must not throw, and whole-file range output must match full-file format (with prefix/suffix ranges and both **`alignInGroups`** values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8fa315cb5aa7b3b6a3fbdaa282a5b95330a3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->